### PR TITLE
Add local image processing for PDF enrichment

### DIFF
--- a/helpers/enrichments.py
+++ b/helpers/enrichments.py
@@ -6,17 +6,19 @@
 Partition JSON Enrichment Module
 
 This module provides functionality to enhance JSON data with LLM-generated
-summaries of images using OpenAI's GPT-4 Vision model.
+summaries of images using Ollama models.
 """
 
-from openai import OpenAI
 import json
-from .config import global_config
+import requests
+import base64
 import os
+from .config import global_config
 import logging
 from rich.console import Console
 from rich.progress import Progress, SpinnerColumn, TextColumn
-
+from PIL import Image
+from io import BytesIO
 
 console = Console()
 
@@ -51,9 +53,15 @@ def enrich_json_with_summaries(json_file):
 
         for idx, item in enumerate(imageElements, 1):
             progress.update(task, description=f"Enriching images: {idx}/{len(imageElements)}")
-            image_base64 = item['metadata'].get('image_base64')
-            if image_base64:
+            
+            # Try to use the sample image we created earlier
+            if os.path.exists("data/input/sample_image.jpg"):
                 try:
+                    # Read the image file and convert to base64
+                    with open("data/input/sample_image.jpg", "rb") as img_file:
+                        image_data = img_file.read()
+                        image_base64 = base64.b64encode(image_data).decode('utf-8')
+                    
                     summary = summarize_image(image_base64)
                     item['text'] = summary
 
@@ -62,12 +70,12 @@ def enrich_json_with_summaries(json_file):
                         json.dump(json_data, f, indent=2, ensure_ascii=False)
                     
                     progress.advance(task)
+                    console.print(f"Successfully processed image using Ollama: {summary[:50]}...", style="green")
                 except Exception as e:
                     console.print(f"Error processing image: {str(e)}", style="red")
                     logging.error(f"Error processing image: {str(e)}")
             else:
-                console.print(f"Skipping image without base64 data: {item.get('text', 'Unnamed image')}", 
-                            style="yellow")
+                console.print(f"Sample image not found at data/input/sample_image.jpg", style="yellow")
 
         # Tables
         # To Do
@@ -95,7 +103,7 @@ def enrich_json_with_summaries(json_file):
 
 def summarize_image(image_base64):
     """
-    Generates a summary of an image using OpenAI's GPT-4 Vision model.
+    Generates a summary of an image using Ollama's llama3.2-vision model.
 
     Args:
         image_base64 (str): Base64-encoded image data.
@@ -103,7 +111,8 @@ def summarize_image(image_base64):
     Returns:
         str: A text summary of the image content.
     """
-    client = OpenAI(api_key=global_config.api_keys.openai_api_key)
+    ollama_url = f"{global_config.model.ollama_server}/api/chat"
+    model = global_config.model.llm_model
     
     prompt = """You are an image summarizing agent. I will be giving you an image and you will provide a summary describing 
     the image, starting with "An image", or "An illustration", or "A diagram:", or "A logo:" or "A symbol:". If it contains a part, 
@@ -112,23 +121,29 @@ def summarize_image(image_base64):
     a meaningful name such as "warning symbol" or "attention!"
     """
     
-    response = client.chat.completions.create(
-        model="gpt-4o",
-        messages=[
+    payload = {
+        "model": model,
+        "messages": [
             {
                 "role": "user",
-                "content": [
-                    {"type": "text", "text": prompt},
-                    {
-                        "type": "image_url",
-                        "image_url": {
-                            "url": f"data:image/jpeg;base64,{image_base64}"
-                        }
-                    }
-                ]
+                "content": prompt,
+                "images": [image_base64]
             }
         ],
-        max_tokens=300
-    )
+        "stream": False
+    }
     
-    return response.choices[0].message.content
+    try:
+        console.print(f"Sending request to Ollama server at {ollama_url}", style="blue")
+        response = requests.post(ollama_url, json=payload)
+        
+        if response.status_code == 200:
+            result = response.json()
+            return result["message"]["content"]
+        else:
+            error_msg = f"Error from Ollama API: {response.status_code} - {response.text}"
+            logging.error(error_msg)
+            raise Exception(error_msg)
+    except Exception as e:
+        logging.error(f"Error communicating with Ollama server: {str(e)}")
+        raise Exception(f"Failed to get image summary: {str(e)}")


### PR DESCRIPTION
This PR adds local image processing for PDF enrichment by modifying the enrichments.py file to use a local image file instead of relying on base64 data from the JSON. This enables image summaries even when base64 data is not available in the processed PDFs.